### PR TITLE
:bug: fix vault-secrets-operator and chart namespaces

### DIFF
--- a/manifests/vault/ocf-vault-vault-secrets-operator-test-connection_Pod_vault.yaml
+++ b/manifests/vault/ocf-vault-vault-secrets-operator-test-connection_Pod_vault.yaml
@@ -4,15 +4,15 @@ metadata:
   annotations:
     helm.sh/hook: test-success
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: ocf-vault-secrets-operator-test-connection
+  name: ocf-vault-vault-secrets-operator-test-connection
 spec:
   containers:
   - args:
-    - ocf-vault-secrets-operator:8081/healthz
+    - ocf-vault-vault-secrets-operator:8081/healthz
     command:
     - wget
     image: busybox:latest

--- a/manifests/vault/ocf-vault-vault-secrets-operator-vault_ClusterRoleBinding_vault.yaml
+++ b/manifests/vault/ocf-vault-vault-secrets-operator-vault_ClusterRoleBinding_vault.yaml
@@ -2,17 +2,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: ocf-vault-secrets-operator
+  name: ocf-vault-vault-secrets-operator-vault
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vault-secrets-operator
+  name: vault-secrets-operator-vault
 subjects:
 - apiGroup: ''
   kind: ServiceAccount
   name: vault-secrets-operator
-  namespace: vault-secrets-operator
+  namespace: vault

--- a/manifests/vault/ocf-vault-vault-secrets-operator_ClusterRoleBinding_vault.yaml
+++ b/manifests/vault/ocf-vault-vault-secrets-operator_ClusterRoleBinding_vault.yaml
@@ -2,17 +2,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: ocf-vault-secrets-operator-vault-secrets-operator
+  name: ocf-vault-vault-secrets-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vault-secrets-operator-vault-secrets-operator
+  name: vault-secrets-operator
 subjects:
 - apiGroup: ''
   kind: ServiceAccount
   name: vault-secrets-operator
-  namespace: vault-secrets-operator
+  namespace: vault

--- a/manifests/vault/ocf-vault-vault-secrets-operator_Deployment_vault.yaml
+++ b/manifests/vault/ocf-vault-vault-secrets-operator_Deployment_vault.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: ocf-vault-secrets-operator
+  name: ocf-vault-vault-secrets-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance: ocf-vault-secrets-operator
+      app.kubernetes.io/instance: ocf-vault
       app.kubernetes.io/name: vault-secrets-operator
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: ocf-vault-secrets-operator
+        app.kubernetes.io/instance: ocf-vault
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: vault-secrets-operator
         helm.sh/chart: vault-secrets-operator-1.14.5
@@ -30,7 +30,7 @@ spec:
         - name: WATCH_NAMESPACE
           value: ''
         - name: VAULT_ADDRESS
-          value: http://vault:8200
+          value: http://ocf-vault:8200
         - name: VAULT_AUTH_METHOD
           value: kubernetes
         - name: VAULT_TOKEN_PATH

--- a/manifests/vault/ocf-vault-vault-secrets-operator_Service_vault.yaml
+++ b/manifests/vault/ocf-vault-vault-secrets-operator_Service_vault.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: ocf-vault-secrets-operator
+  name: ocf-vault-vault-secrets-operator
 spec:
   ports:
   - name: http-metrics
@@ -18,6 +18,6 @@ spec:
     protocol: TCP
     targetPort: http
   selector:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/name: vault-secrets-operator
   type: ClusterIP

--- a/manifests/vault/vault-secrets-operator-vault_ClusterRole_vault.yaml
+++ b/manifests/vault/vault-secrets-operator-vault_ClusterRole_vault.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5
-  name: vault-secrets-operator-vault-secrets-operator
+  name: vault-secrets-operator-vault
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/manifests/vault/vault-secrets-operator_ClusterRole_vault.yaml
+++ b/manifests/vault/vault-secrets-operator_ClusterRole_vault.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5

--- a/manifests/vault/vault-secrets-operator_ServiceAccount_vault.yaml
+++ b/manifests/vault/vault-secrets-operator_ServiceAccount_vault.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5

--- a/manifests/vault/vaultsecrets.ricoberger.de_CustomResourceDefinition_vault.yaml
+++ b/manifests/vault/vaultsecrets.ricoberger.de_CustomResourceDefinition_vault.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: ocf-vault-secrets-operator
+    app.kubernetes.io/instance: ocf-vault
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-secrets-operator
     helm.sh/chart: vault-secrets-operator-1.14.5

--- a/ocfkube/apps/vault.py
+++ b/ocfkube/apps/vault.py
@@ -35,7 +35,12 @@ values = {
     "ui": {"enabled": True},
 }
 
-values_vso = {"vault": {"authMethod": "kubernetes"}}
+values_vso = {
+    "vault": {
+        "authMethod": "kubernetes",
+        "address": "http://ocf-vault:8200",
+    },
+}
 
 
 def build() -> object:
@@ -45,6 +50,7 @@ def build() -> object:
         values=values,
     ) + helm.build_chart_from_versions(
         name="vault-secrets-operator",
+        namespace="vault",
         versions=versions,
         values=values_vso,
     )

--- a/ocfkube/utils/helm.py
+++ b/ocfkube/utils/helm.py
@@ -72,11 +72,12 @@ def build_chart_from_versions(
     name: str,
     versions: dict[str, Any],
     values: dict,
+    namespace: str = None,
 ):
     return build_chart(
         repo_url=versions[name]["helm"],
         chart_name=versions[name].get("chart", name),
-        namespace=name,
+        namespace=namespace or name,
         version=versions[name]["version"],
         values=values,
     )


### PR DESCRIPTION
Allow namespace name to be passed to helm when rendering chart, instead of always using the chart name so that charts "see" the correct namespace. Also set the URL of vault correctly for vault-secrets-operator. With this, VSO is now functional :sparkles:
