### PR TITLE
:hammer: remove secret checksums from Harbor deployments

### DIFF
--- a/manifests/harbor/ocf-harbor-chartmuseum_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-chartmuseum_Deployment_harbor.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       annotations:
         checksum/configmap-envvars: 44c5cbe7982b2a2b39bf89dccc42a4a40c413436c36d035218cfa421e68d6b2d
-        checksum/secret: 6150cb581862bbc3e22cc63bc80976c1dc5edb7920e2a4cd737bb4a461e2540f
-        checksum/secret-core: a62624694d8a1c78bb6ba1dbb5e88dfa865bd255a0430148bb98411aaa57f3e0
       labels:
         app.kubernetes.io/component: chartmuseum
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-core_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-core_Deployment_harbor.yaml
@@ -22,9 +22,6 @@ spec:
       annotations:
         checksum/configmap: a0ab4454c2fe1d3f57871e1cf9c8f836a9bc6059aa09c9d2102ee890ebfdec74
         checksum/configmap-envvars: 3b35112645ecb5545620d410ab254ec63da5cd13992f9a4216a629b5af21731d
-        checksum/secret: a62624694d8a1c78bb6ba1dbb5e88dfa865bd255a0430148bb98411aaa57f3e0
-        checksum/secret-envvars: b3195cf8e0af4f6a0c3a540169237e2487f9dae6381ca949db7309d86ca4981a
-        checksum/secret-jobservice: 94dfb2c271df0cc15f4aeaad6a25dd05d22764f0c3492216d893c79471d3ff8a
       labels:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-jobservice_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-jobservice_Deployment_harbor.yaml
@@ -22,9 +22,6 @@ spec:
       annotations:
         checksum/configmap: defa3bf0da02ec0e1452f19e547b02db46800fbb760c1465c6856d2bcac401e0
         checksum/configmap-env: 50006a26f4cbe1856df9756d1b1e84f6e5276b06448e77d7fc43a115a28a1d50
-        checksum/secret: 1c6cdde529c9ad79195beda2c58946ce3cc1782e5dedf50fb0aa371b8b7d8733
-        checksum/secret-core: a62624694d8a1c78bb6ba1dbb5e88dfa865bd255a0430148bb98411aaa57f3e0
-        checksum/secret-env: 84c62e5340ae9700946d293ce693684d1b673c9dc3dadf093bcb152c6ff751d0
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-notary-server_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-notary-server_Deployment_harbor.yaml
@@ -19,9 +19,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/secret: b4c478987b46c49a7b5f22c4ab13a18d13dff3b980f79546336551f4f8b92a9f
-        checksum/secret-core: a62624694d8a1c78bb6ba1dbb5e88dfa865bd255a0430148bb98411aaa57f3e0
+      annotations: {}
       labels:
         app.kubernetes.io/component: notary-server
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-notary-signer_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-notary-signer_Deployment_harbor.yaml
@@ -19,8 +19,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/secret: 7582b804dd9bfb107b5b7b8c4334ff2a0dd746a4a06f627db343641b63c3e0c2
+      annotations: {}
       labels:
         app.kubernetes.io/component: notary-signer
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-redis-master_StatefulSet_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-redis-master_StatefulSet_harbor.yaml
@@ -22,7 +22,6 @@ spec:
         checksum/configmap: 948b8e6326edf71e01ceb60ccd28b969b833d0e80188187dbdab5504c588362c
         checksum/health: 92353c2e04ad7273ded92617a1237e1a4e91cc385db687e1842537720d1ea254
         checksum/scripts: d18997e7547c7efc210c23a4f40e561f43feb43dae5dfdbb1d017c19c22b7e95
-        checksum/secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
         app.kubernetes.io/component: master
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-registry_Deployment_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-registry_Deployment_harbor.yaml
@@ -21,9 +21,6 @@ spec:
     metadata:
       annotations:
         checksum/configmap: e33a881fb69efbb172f5b683bd7a9acc26b0e6bf279fd034db891fb7b0c47915
-        checksum/secret: 32adfafa2cb65c913e4b8c9168a9c146fd00a5c6caa84344f843c34582c73f27
-        checksum/secret-core: a62624694d8a1c78bb6ba1dbb5e88dfa865bd255a0430148bb98411aaa57f3e0
-        checksum/secret-jobservice: 82782c132c4ea59ac330ee394be53bd10d75a8d48f065a21b9727949ae2e8126
       labels:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: ocf-harbor

--- a/manifests/harbor/ocf-harbor-trivy_StatefulSet_harbor.yaml
+++ b/manifests/harbor/ocf-harbor-trivy_StatefulSet_harbor.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       annotations:
         checksum/configmap-env: cd7efefdfa1d39195c8e4fe6791675b1943ed31ac9fdf668ea0767181bc145f5
-        checksum/secret-env: 3b9c37a7e3e06ea4cb65cc5920e672d422b13bb23696e3b88a16ce287f581a2d
       labels:
         app.kubernetes.io/component: trivy
         app.kubernetes.io/instance: ocf-harbor

--- a/ocfkube/apps/harbor.py
+++ b/ocfkube/apps/harbor.py
@@ -1,5 +1,6 @@
 from ocfkube.utils import helm
 from ocfkube.utils import versions
+from ocfkube.utils.json import delve
 
 values = {
     "service": {
@@ -29,9 +30,26 @@ values = {
 }
 
 
+def strip_secret_checksum(m):
+    """
+    Bludgeon all checksum annotations for secrets since they are managed in
+    vault, and the chart autogenerates certificates which change each run
+    """
+    # spec.template.metadata.annotations['checksum/secret*']
+    annotations = delve(m, ("spec", "template", "metadata", "annotations"))
+    if annotations is not None:
+        for key, value in list(annotations.items()):
+            if key.startswith("checksum/secret"):
+                del annotations[key]
+    return m
+
+
 def build() -> object:
-    return helm.build_chart_from_versions(
-        name="harbor",
-        versions=versions,
-        values=values,
-    )
+    return [
+        strip_secret_checksum(m)
+        for m in helm.build_chart_from_versions(
+            name="harbor",
+            versions=versions,
+            values=values,
+        )
+    ]

--- a/ocfkube/utils/json.py
+++ b/ocfkube/utils/json.py
@@ -1,0 +1,18 @@
+from typing import Iterable, Optional, Any
+
+
+__all__ = ["delve"]
+
+
+def delve(obj: dict, path: Iterable[str]) -> Optional[Any]:
+    """
+    Get the element of the nested dict at the path provided, returning None if
+    any keys along the way do not exist
+    """
+    curr = obj
+    for key in path:
+        try:
+            curr = curr[key]
+        except KeyError:
+            return None
+    return curr


### PR DESCRIPTION
The Harbor chart generates a bunch of secrets in Helm, which results in the secret checksums changing every run (even though the real secrets won't change since those are stored separately in Vault). Instead of trying to get the chart to not, remove all checksums related to secrets (it seems that the keys in question on the secrets are not even used in our configuration).
