### PR TITLE
:screwdriver: allow ArgoCD HAProxy deployment to progress

### DIFF
--- a/manifests/argocd/argocd-redis-ha-haproxy_Deployment_argocd.yaml
+++ b/manifests/argocd/argocd-redis-ha-haproxy_Deployment_argocd.yaml
@@ -13,6 +13,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
   strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Previously, due to the node antiaffinity on HAProxy pods combined with our schedulable node count exactly equaling the replica count, ArgoCD's (internal) HAProxy deployment would not be able to progress since there are no nodes to schedule the new pods on. Adjust the rolling update strategy to limit the max pods to 3 at a time.

~~This PR depends on (the bugfixes in) #32; once that PR is merged, this PR should be rebased. It is ready for review but should not be merged right now, hence the draft state. Only the last commit is "actually" part of the PR.~~ #32 has been merged, this PR is ready :tada: