### PR TITLE
Nelcel/#34

### DIFF
--- a/ocfkube/utils/helm.py
+++ b/ocfkube/utils/helm.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from sys import stdout
 import tempfile
 from subprocess import PIPE
 from subprocess import run

--- a/ocfkube/utils/helm.py
+++ b/ocfkube/utils/helm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from sys import stdout
 import tempfile
 from subprocess import PIPE
 from subprocess import run
@@ -95,6 +96,31 @@ def build_chart(
     if shutil.which("helm") is None:
         raise RuntimeError("You must install Helm to use this script.")
 
+    # make sure the current user has a place for us to cache stuff
+    cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'ocf_helm')
+    if not os.path.isdir(cache_dir):
+        os.mkdir(cache_dir)
+
+    # if the compressed chart is in our cache and it's of the right version
+    archive_name = f"{name}-{version}.tgz"
+    exists = os.path.isfile(os.path.join(cache_dir, archive_name))
+
+    # if we don't have the chart, download it (as an archive)
+    if not exists:
+        pull_args = [
+            "helm",
+            "pull",
+            "-d", cache_dir,
+            "--version", version,
+            "--repo", repo_url,
+            chart_name
+        ]
+        should_be_empty = run(
+            pull_args, 
+            check=True, 
+            stderr=PIPE,
+        ).stderr
+
     values_file, values_file_name = tempfile.mkstemp(suffix=".yml")
     with open(values_file_name, "w") as f:
         f.write(yaml.dump(values))
@@ -104,10 +130,10 @@ def build_chart(
         "template",
         "-n",
         namespace,
-        "--repo",
-        repo_url,
-        "--version",
-        version,
+        # "--repo",
+        # repo_url,
+        # "--version",
+        # version,
         "--values",
         values_file_name,
         "--include-crds",
@@ -117,7 +143,7 @@ def build_chart(
         f"ocf-{name}",
         "--api-versions",
         ", ".join(capabilities),
-        chart_name,
+        archive_name,
     ]
     r = run(
         tpl_args,


### PR DESCRIPTION
With a bit of Googling, I found `helm pull`, which downloads charts without installing them. In conjunction, a bit of playing around with `helm template` made it seem like it could accept chart archives downloaded from `helm pull`. So the plan was clear:  
1. check if we have the right chart archive (I picked `~/.cache/ocf_helm` so as to not overlap with the helm default cache)
2. if not, download it
3. run `helm template` on the archive in the cache

I found that although `helm pull` could also extract the chart, the name it would give the resulting folder was too generic (just the name of the chart) and was inconvenient to account for multiple cached versions of a chart, so I stuck with the archive. I'm not sure if the output of the pull command is useful since it's silent on success, so although I capture `stderr`, I don't actually pass it out of `build_chart()`.