### PR TITLE
keycloak on newk8s

### DIFF
--- a/apps/argocd.py
+++ b/apps/argocd.py
@@ -50,7 +50,7 @@ def objects():
                     "oidc.config": yaml.dump(
                         {
                             "name": "Keycloak",
-                            "issuer": "https://auth.ocf.berkeley.edu/auth/realms/ocf",
+                            "issuer": "https://idm.ocf.berkeley.edu/realms/ocf",
                             "clientID": "argocd",
                             "clientSecret": "$oidc.keycloak.clientSecret",
                             "requestedScopes": [

--- a/apps/keycloak.py
+++ b/apps/keycloak.py
@@ -299,7 +299,7 @@ helm_values = {
     "auth": {"existingSecret": "keycloak", "existingSecretKey": "admin-password"},
     "production": True,
     "proxy": "edge",
-    "httpRelativePath": "/auth/",
+    "httpRelativePath": "/",
     "replicaCount": 2,
     "ingress": {
         "enabled": True,

--- a/apps/keycloak.py
+++ b/apps/keycloak.py
@@ -1,0 +1,379 @@
+import json
+
+from transpire import helm
+from transpire.resources import ConfigMap
+from transpire.utils import get_versions
+
+name = "keycloak"
+
+
+def oidc_client(
+    client_id: str,
+    *,
+    name: str,
+    description: str,
+    home_url: str,
+    redirect_uris: list[str],
+):
+    return {
+        "clientId": client_id,
+        "name": name,
+        "description": description,
+        "baseUrl": home_url,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": redirect_uris,
+        "webOrigins": ["+"],
+        "publicClient": False,
+        "protocol": "openid-connect",
+        "enabled": True,
+    }
+
+
+clients = [
+    oidc_client(
+        "argocd",
+        name="ArgoCD",
+        description="Declarative GitOps CD for Kubernetes",
+        home_url="https://argo.ocf.berkeley.edu/",
+        redirect_uris=["https://argo.ocf.berkeley.edu/auth/callback"],
+    ),
+    oidc_client(
+        "hedgedoc",
+        name="HedgeDoc",
+        description="Collaborative Markdown Notes",
+        home_url="https://notes.ocf.berkeley.edu/",
+        redirect_uris=["https://notes.ocf.berkeley.edu/auth/oauth2/callback"],
+    ),
+]
+
+keycloak_config_cli = {
+    "id": "ocf",
+    "realm": "ocf",
+    "displayName": "OCF",
+    "sslRequired": "all",
+    "enabled": True,
+    "registrationAllowed": False,
+    "loginWithEmailAllowed": False,
+    "loginTheme": "ocf-theme",
+    "accountTheme": "keycloak.v2",
+    "adminTheme": "keycloak.v2",
+    "emailTheme": "keycloak",
+    "roles": {
+        "realm": [
+            {"name": "ocfstaff", "composite": False, "clientRole": False},
+            {"name": "ocfroot", "composite": False, "clientRole": False},
+            {"name": "opstaff", "composite": False, "clientRole": False},
+        ]
+    },
+    "groups": [
+        {"name": "ocf"},
+        {"name": "ocfalumni"},
+        {"name": "ocfapphost"},
+        {"name": "ocfhpc"},
+        {"name": "ocfofficers"},
+        {
+            "name": "ocfroot",
+            "realmRoles": ["ocfroot"],
+            "clientRoles": {
+                "realm-management": [
+                    "manage-clients",
+                    "manage-events",
+                    "manage-identity-providers",
+                    "manage-realm",
+                    "manage-users",
+                    "manage-authorization",
+                    "realm-admin",
+                ]
+            },
+        },
+        {"name": "ocfstaff", "realmRoles": ["ocfstaff"]},
+        {"name": "opstaff", "realmRoles": ["opstaff"]},
+        {"name": "sorry"},
+    ],
+    "clients": clients,
+    "clientScopes": [
+        {
+            "name": "groups",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+            },
+            "protocolMappers": [
+                {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-group-membership-mapper",
+                    "consentRequired": False,
+                    "config": {
+                        "full.path": "false",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "groups",
+                        "userinfo.token.claim": "true",
+                    },
+                }
+            ],
+        }
+    ],
+    "defaultDefaultClientScopes": [
+        "acr",
+        "email",
+        "profile",
+        "roles",
+        "web-origins",
+        "groups",
+    ],
+    "components": {
+        "org.keycloak.storage.UserStorageProvider": [
+            {
+                "name": "ldap",
+                "providerId": "ldap",
+                "config": {
+                    "enabled": ["true"],
+                    "vendor": ["other"],
+                    "connectionUrl": ["ldaps://ldap.ocf.berkeley.edu"],
+                    "useTruststoreSpi": ["ldapsOnly"],
+                    "connectionPooling": ["true"],
+                    "authType": ["none"],
+                    "editMode": ["READ_ONLY"],
+                    "usersDn": ["ou=People,dc=OCF,dc=Berkeley,dc=EDU"],
+                    "usernameLDAPAttribute": ["uid"],
+                    "rdnLDAPAttribute": ["uid"],
+                    "uuidLDAPAttribute": ["uid"],
+                    "userObjectClasses": ["ocfAccount,account,posixAccount"],
+                    "customUserSearchFilter": [
+                        "(!(loginShell=/opt/share/utils/bin/sorried))"
+                    ],
+                    "searchScope": ["1"],
+                    "pagination": ["true"],
+                    "importEnabled": ["true"],
+                    "batchSizeForSync": ["1000"],
+                    "fullSyncPeriod": ["604800"],
+                    "changedSyncPeriod": ["86400"],
+                    "allowKerberosAuthentication": ["true"],
+                    "kerberosRealm": ["OCF.BERKELEY.EDU"],
+                    "serverPrincipal": ["HTTP/lb.ocf.berkeley.edu@OCF.BERKELEY.EDU"],
+                    "keyTab": ["/etc/keytabs/http.keytab"],
+                    "debug": ["true"],
+                    "useKerberosForPasswordAuthentication": ["true"],
+                    "cachePolicy": ["DEFAULT"],
+                    "syncRegistrations": ["false"],
+                    "validatePasswordPolicy": ["false"],
+                    "trustEmail": ["true"],
+                    "priority": ["0"],
+                },
+                "subComponents": {
+                    "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+                        {
+                            "name": "username",
+                            "providerId": "user-attribute-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "ldap.attribute": ["uid"],
+                                "is.mandatory.in.ldap": ["true"],
+                                "always.read.value.from.ldap": ["false"],
+                                "read.only": ["true"],
+                                "user.model.attribute": ["username"],
+                            },
+                        },
+                        {
+                            "name": "email",
+                            "providerId": "user-attribute-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "ldap.attribute": ["ocfEmail"],
+                                "is.mandatory.in.ldap": ["true"],
+                                "is.binary.attribute": ["false"],
+                                "always.read.value.from.ldap": ["false"],
+                                "read.only": ["true"],
+                                "user.model.attribute": ["email"],
+                            },
+                        },
+                        {
+                            "name": "first name",
+                            "providerId": "user-attribute-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "ldap.attribute": ["cn"],
+                                "is.mandatory.in.ldap": ["true"],
+                                "read.only": ["true"],
+                                "always.read.value.from.ldap": ["true"],
+                                "user.model.attribute": ["firstName"],
+                            },
+                        },
+                        {
+                            "name": "creation date",
+                            "providerId": "user-attribute-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "ldap.attribute": ["createTimestamp"],
+                                "is.mandatory.in.ldap": ["false"],
+                                "read.only": ["true"],
+                                "always.read.value.from.ldap": ["true"],
+                                "user.model.attribute": ["createTimestamp"],
+                            },
+                        },
+                        {
+                            "name": "modify date",
+                            "providerId": "user-attribute-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "ldap.attribute": ["modifyTimestamp"],
+                                "is.mandatory.in.ldap": ["false"],
+                                "read.only": ["true"],
+                                "always.read.value.from.ldap": ["true"],
+                                "user.model.attribute": ["modifyTimestamp"],
+                            },
+                        },
+                        {
+                            "name": "group",
+                            "providerId": "group-ldap-mapper",
+                            "subComponents": {},
+                            "config": {
+                                "mode": ["READ_ONLY"],
+                                "membership.attribute.type": ["UID"],
+                                "user.roles.retrieve.strategy": [
+                                    "LOAD_GROUPS_BY_MEMBER_ATTRIBUTE"
+                                ],
+                                "group.name.ldap.attribute": ["cn"],
+                                "preserve.group.inheritance": ["false"],
+                                "ignore.missing.groups": ["false"],
+                                "membership.user.ldap.attribute": ["uid"],
+                                "membership.ldap.attribute": ["memberUid"],
+                                "group.object.classes": ["posixGroup"],
+                                "groups.dn": ["ou=Group,dc=ocf,dc=Berkeley,dc=EDU"],
+                                "memberof.ldap.attribute": ["memberOf"],
+                                "drop.non.existing.groups.during.sync": ["false"],
+                            },
+                        },
+                    ]
+                },
+            }
+        ],
+    },
+}
+
+
+krb5_conf = """
+[libdefaults]
+  default_realm = OCF.BERKELEY.EDU
+
+# The following krb5.conf variables are only for MIT Kerberos.
+  krb4_config = /etc/krb.conf
+  krb4_realms = /etc/krb.realms
+  kdc_timesync = 1
+  ccache_type = 4
+  forwardable = true
+  proxiable = true
+
+# The following libdefaults parameters are only for Heimdal Kerberos.
+  v4_instance_resolve = false
+  v4_name_convert = {
+    host = {
+      rcmd = host
+      ftp = ftp
+    }
+    plain = {
+      something = something-else
+    }
+  }
+  fcc-mit-ticketflags = true
+
+[realms]
+  OCF.BERKELEY.EDU = {
+    kdc = kerberos.ocf.berkeley.edu
+    admin_server = kerberos.ocf.berkeley.edu
+  }
+
+[domain_realm]
+  .ocf.berkeley.edu = OCF.BERKELEY.EDU
+  ocf.berkeley.edu = OCF.BERKELEY.EDU
+
+[login]
+  krb4_convert = true
+  krb4_get_tickets = false
+"""
+
+helm_values = {
+    "auth": {"existingSecret": "keycloak", "existingSecretKey": "admin-password"},
+    "production": True,
+    "proxy": "edge",
+    "httpRelativePath": "/auth/",
+    "replicaCount": 2,
+    "ingress": {
+        "enabled": True,
+        "ingressClassName": "contour",
+        "annotations": {
+            "cert-manager.io/cluster-issuer": "letsencrypt",
+            "ingress.kubernetes.io/force-ssl-redirect": "true",
+            "kubernetes.io/tls-acme": "true",
+        },
+        "hostname": "idm.ocf.berkeley.edu",
+        "tls": True,
+    },
+    "metrics": {"enabled": True},
+    "keycloakConfigCli": {
+        "enabled": True,
+        "existingConfigmap": "keycloak-config-cli",
+        "cleanupAfterFinished": {
+            "enabled": True,
+            "seconds": 0,
+        },
+    },
+    "postgresql": {"enabled": False},
+    "externalDatabase": {
+        "host": "ocf-keycloak",
+        "port": 5432,
+        "user": "keycloak",
+        "database": "keycloak",
+        "existingSecret": "keycloak.ocf-keycloak.credentials.postgresql.acid.zalan.do",
+        "existingSecretPasswordKey": "password",
+    },
+    "extraVolumes": [
+        {
+            "name": "krb5-conf",
+            "configMap": {
+                "name": "krb5-conf",
+            },
+        }
+    ],
+    "extraVolumeMounts": [
+        {
+            "name": "krb5-conf",
+            "mountPath": "/etc/krb5.conf",
+            "subPath": "krb5.conf",
+        }
+    ],
+}
+
+
+def objects():
+    yield ConfigMap("krb5-conf", data={"krb5.conf": krb5_conf}).build()
+    yield ConfigMap(
+        "keycloak-config-cli",
+        data={"configuration": json.dumps(keycloak_config_cli)},
+    ).build()
+
+    yield {
+        "apiVersion": "acid.zalan.do/v1",
+        "kind": "postgresql",
+        "metadata": {"name": "ocf-keycloak"},
+        "spec": {
+            "teamId": "ocf",
+            "volume": {
+                "size": "32Gi",
+                "storageClass": "rbd-nvme",
+            },
+            "numberOfInstances": 1,
+            "users": {"keycloak": ["superuser", "createdb"]},
+            "databases": {"keycloak": "keycloak"},
+            "postgresql": {"version": "14"},
+        },
+    }
+
+    yield from helm.build_chart_from_versions(
+        name=name,
+        versions=get_versions(__file__),
+        values=helm_values,
+    )

--- a/apps/keycloak.py
+++ b/apps/keycloak.py
@@ -153,8 +153,8 @@ keycloak_config_cli = {
                     "changedSyncPeriod": ["86400"],
                     "allowKerberosAuthentication": ["true"],
                     "kerberosRealm": ["OCF.BERKELEY.EDU"],
-                    "serverPrincipal": ["HTTP/lb.ocf.berkeley.edu@OCF.BERKELEY.EDU"],
-                    "keyTab": ["/etc/keytabs/http.keytab"],
+                    "serverPrincipal": ["HTTP/idm.ocf.berkeley.edu@OCF.BERKELEY.EDU"],
+                    "keyTab": ["/vault/secrets/keytab"],
                     "debug": ["true"],
                     "useKerberosForPasswordAuthentication": ["true"],
                     "cachePolicy": ["DEFAULT"],
@@ -301,6 +301,19 @@ helm_values = {
     "proxy": "edge",
     "httpRelativePath": "/",
     "replicaCount": 2,
+    "podAnnotations": {
+        "vault.hashicorp.com/agent-inject": "true",
+        "vault.hashicorp.com/role": "keycloak",
+        "vault.hashicorp.com/service": "https://vault.ocf.berkeley.edu/",
+        "vault.hashicorp.com/agent-inject-secret-keytab": "kvv2/data/keycloak/keycloak",
+        "vault.hashicorp.com/agent-inject-template-keytab": (
+            "{{`"
+            '{{- with secret "kvv2/data/keycloak/keycloak" -}}'
+            "{{ base64Decode .Data.data.keytab }}"
+            "{{- end}}"
+            "`}}"
+        ),
+    },
     "ingress": {
         "enabled": True,
         "ingressClassName": "contour",

--- a/apps/keycloak.py
+++ b/apps/keycloak.py
@@ -381,7 +381,7 @@ def objects():
             "numberOfInstances": 1,
             "users": {"keycloak": ["superuser", "createdb"]},
             "databases": {"keycloak": "keycloak"},
-            "postgresql": {"version": "14"},
+            "postgresql": {"version": "15"},
         },
     }
 

--- a/apps/versions.toml
+++ b/apps/versions.toml
@@ -58,6 +58,10 @@ helm = "https://charts.bitnami.com/bitnami"
 version = "2.9.1"
 helm = "https://kedacore.github.io/charts"
 
+[keycloak]
+version = "16.1.2"
+helm = "https://charts.bitnami.com/bitnami"
+
 [kubevirt]
 version = "v0.59.0-alpha.2"
 github = "https://github.com/kubevirt/kubevirt"

--- a/cluster.toml
+++ b/cluster.toml
@@ -24,6 +24,7 @@ contour = { path = "apps/contour.py" }
 fission = { path = "apps/fission.py" }
 harbor = { path = "apps/harbor.py" }
 keda = { path = "apps/keda.py" }
+keycloak = { path = "apps/keycloak.py" }
 kubevirt = { path = "apps/kubevirt.py" }
 metallb = { path = "apps/metallb.py" }
 metrics-server = { path = "apps/metrics_server.py" }


### PR DESCRIPTION
Migrating from oldk8s. This new deployment is configured via [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli), which lets us write a declarative (ish) configuration file instead of doing everything through the UI.

Going forward, there are two options, either:

1. Switch completely to the new deployment in one step. The new deployment will be at the same url as the old one.
2. Put the new deployment at a different domain, and gradually migrate clients.

Since (1) would require migrating every single client at once, and would be difficult (if even possible) to test properly before committing to it, I've decided to go with (2) *for now*. This new one is on https://idm.ocf.berkeley.edu, and [argocd](https://argo.ocf.berkeley.edu/) and [notes](https://notes.ocf.berkeley.edu/) have already been migrated to use it.