### PR TITLE
ceph: remove failing tls from internal rgw-hdd endpoint

### DIFF
--- a/apps/rook.py
+++ b/apps/rook.py
@@ -337,7 +337,6 @@ def objects():
             },
             "preservePoolsOnDelete": True,
             "gateway": {
-                "securePort": 443,
                 "port": 80,
                 "instances": 1,
             },


### PR DESCRIPTION
getting the following error and thought this made the most sense because we already have tls setup for ingress so like I think this doesn't really break anything. we likely upgraded ceph and got this error now? (this has been failing for like >100d)

```
2026-05-06 20:33:53.173573 E | ceph-object-controller: failed to reconcile CephObjectStore "rook/rgw-hdd". failed to create object store deployments: failed to create object store "rgw-hdd": failed to start rgw pods: failed to create rgw deployment: no TLS certificates found
```