### PR TITLE
bitnami legacy images

### DIFF
--- a/apps/contour.py
+++ b/apps/contour.py
@@ -9,7 +9,10 @@ def objects():
         name=name,
         versions=get_versions(__file__),
         values={
+            "global": {"security":{"allowInsecureImages": True}},
+            "contour": {"image": {"repository": "bitnamilegacy/contour"}},
             "envoy": {
+                "image": {"repository": "bitnamilegacy/envoy"},
                 "service": {
                     "annotations": {
                         "metallb.universe.tf/loadBalancerIPs": "169.229.226.81,2607:f140:8801::1:81",

--- a/apps/metallb.py
+++ b/apps/metallb.py
@@ -28,8 +28,13 @@ def objects():
         name="metallb",
         versions=get_versions(__file__),
         values={
+            "global": {"security":{"allowInsecureImages": True}},
             "controller": {
+                "image": {"repository": "bitnamilegacy/metallb-controller"},
                 "metrics": {"enabled": True, "serviceMonitor": {"enabled": True}}
+            },
+            "speaker": {
+                "image": {"repository": "bitnamilegacy/metallb-speaker"}
             }
         },
     )


### PR DESCRIPTION
right now, due to the stupid bitnami changes, our bitnami helm charts only run because some nodes have the containers cached lol, which means they cannot run if pods get scheduled to any other node

this is not a permanent solution at all, i think long term we should move away from bitnami charts, but hopefully this should allow us to not have issues at least temporarily